### PR TITLE
add "inline" rendering option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,15 +49,21 @@ function replaceUrlWithGraph(node, vFile) {
  *
  * @param {object} ast
  * @param {vFile} vFile
+ * @param {boolean} inlineMode
  * @return {function}
  */
-function visitCodeBlock(ast, vFile) {
+function visitCodeBlock(ast, vFile, inlineMode) {
   return visit(ast, 'code', (node, index, parent) => {
     const { lang, value, position } = node;
     const destinationDir = getDestinationDir(vFile);
 
     // If this codeblock is not a known graphviz format, bail.
     if (!validLanguages.includes(lang)) {
+      return node;
+    }
+
+    if (inlineMode) {
+      parent.children.splice(index, 1, utils.renderToImgTag(value, lang));
       return node;
     }
 
@@ -116,7 +122,9 @@ function visitImage(ast, vFile) {
  * @link https://github.com/vfile/vfile
  * @return {function}
  */
-function graphviz() {
+function graphviz(options = {}) {
+  const inlineMode = options.inline || false;
+
   /**
    * @param {object} ast MDAST
    * @param {vFile} vFile
@@ -124,7 +132,7 @@ function graphviz() {
    * @return {object}
    */
   return function transformer(ast, vFile, next) {
-    visitCodeBlock(ast, vFile);
+    visitCodeBlock(ast, vFile, inlineMode);
     visitLink(ast, vFile);
     visitImage(ast, vFile);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,21 @@ const PLUGIN_NAME = 'remark-graphviz';
 
 /**
  * Accepts the `source` of the graph, and an `engine` to render an SVG using viz.js.
+ * Returns a MDAST representation of a HTML node.
+ *
+ * @param  {string} source
+ * @param  {string} engine 'dot' or 'circo'
+ * @return {object}
+ */
+function renderToImgTag(source, engine) {
+  return {
+    type: 'html',
+    value: `<img src="data:image/svg+xml;utf8,${encodeURIComponent(viz(source, { engine }))}" />`,
+  };
+}
+
+/**
+ * Accepts the `source` of the graph, and an `engine` to render an SVG using viz.js.
  * Returns the path to the rendered SVG.
  *
  * @param  {string} destination
@@ -42,5 +57,6 @@ function getDestinationDir(vFile) {
 
 module.exports = {
   render,
+  renderToImgTag,
   getDestinationDir,
 };


### PR DESCRIPTION
Hi,

I wanted to use this with `docz`, which does not really work with a file being generated in the same folder.

So I added an inline option - maybe it is useful for other people, too :)